### PR TITLE
Add tsconfig for extension

### DIFF
--- a/src/extension/tsconfig.json
+++ b/src/extension/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist/",
+    "sourceMap": true,
+    "noImplicitAny": true,
+    "module": "es6",
+    "target": "es5",
+    "allowJs": true,
+    "lib": ["es6", "dom", "esnext.asynciterable"]
+  }
+}


### PR DESCRIPTION
Hi @bendersej,

Thank you for sharing this repo.  I might be using it incorrectly but when I cloned it and installed the dependencies I saw this error in VisualStudioCode "Cannot find name 'chrome'":

![Screenshot_2021-07-09_at_09_23_21](https://user-images.githubusercontent.com/526509/125048593-ffba1200-e097-11eb-8e7e-282928b41084.png)

It seems to be fixed by the inclusion of a tsconfig file (a copy of cllient/tsconfig.json minus the `"jsx": "react",` line).